### PR TITLE
GSU: Correct SNES addr -> gamepak RAM mappings

### DIFF
--- a/verilog/sd2snes_gsu/address.v
+++ b/verilog/sd2snes_gsu/address.v
@@ -68,8 +68,8 @@ assign IS_ROM = ((!SNES_ADDR[22] & SNES_ADDR[15])
 
 assign IS_SAVERAM = SAVERAM_MASK[0]
                     & ~SNES_ROMSEL                    
-                    & ( // 70-7F/F0-FF:0000-FFFF
-                        &SNES_ADDR[22:20]
+                    & ( // 70-71/F0-F1:0000-FFFF
+                        (SNES_ADDR[22:17] == 6'b111000)
                         // 00-3F/80-BF:6000-7FFF
                         | (  ~SNES_ADDR[22]
                           &  ~SNES_ADDR[15]
@@ -81,8 +81,8 @@ assign IS_WRITABLE = IS_SAVERAM;
 
 // GSU has a weird hybrid of Lo and Hi ROM formats.
 assign SRAM_SNES_ADDR = (IS_SAVERAM
-                         // 70-7F/F0-FF:0000-FFFF or 00-3F/80-BF:6000-7FFF (first 8K mirror)
-                         ? (24'hE00000 + ((SNES_ADDR[22] ? SNES_ADDR[19:0] : SNES_ADDR[12:0]) & SAVERAM_MASK))
+                         // 70-71/F0-F1:0000-FFFF or 00-3F/80-BF:6000-7FFF
+                         ? (24'hE00000 + ((SNES_ADDR[22] ? SNES_ADDR[16:0] : {SNES_ADDR[19:16], SNES_ADDR[12:0]}) & SAVERAM_MASK))
                          // 40-5F/C0-DF:0000-FFFF or 00-3F/80-BF:8000-FFFF
                          : ((SNES_ADDR[22] ? {2'b00, SNES_ADDR[21:0]} : {2'b00, SNES_ADDR[22:16], SNES_ADDR[14:0]}) & ROM_MASK)
                          );

--- a/verilog/sd2snes_gsu/address.v
+++ b/verilog/sd2snes_gsu/address.v
@@ -68,8 +68,8 @@ assign IS_ROM = ((!SNES_ADDR[22] & SNES_ADDR[15])
 
 assign IS_SAVERAM = SAVERAM_MASK[0]
                     & ~SNES_ROMSEL                    
-                    & ( // 70-71/F0-F1:0000-FFFF
-                        (SNES_ADDR[22:17] == 6'b111000)
+                    & ( // 60-7F/E0-FF:0000-FFFF
+                        &SNES_ADDR[22:21]
                         // 00-3F/80-BF:6000-7FFF
                         | (  ~SNES_ADDR[22]
                           &  ~SNES_ADDR[15]
@@ -81,7 +81,7 @@ assign IS_WRITABLE = IS_SAVERAM;
 
 // GSU has a weird hybrid of Lo and Hi ROM formats.
 assign SRAM_SNES_ADDR = (IS_SAVERAM
-                         // 70-71/F0-F1:0000-FFFF or 00-3F/80-BF:6000-7FFF
+                         // 60-7F/E0-FF:0000-FFFF or 00-3F/80-BF:6000-7FFF
                          ? (24'hE00000 + ((SNES_ADDR[22] ? SNES_ADDR[16:0] : {SNES_ADDR[19:16], SNES_ADDR[12:0]}) & SAVERAM_MASK))
                          // 40-5F/C0-DF:0000-FFFF or 00-3F/80-BF:8000-FFFF
                          : ((SNES_ADDR[22] ? {2'b00, SNES_ADDR[21:0]} : {2'b00, SNES_ADDR[22:16], SNES_ADDR[14:0]}) & ROM_MASK)


### PR DESCRIPTION
This commit contains a few fixes to the mapping from SNES addresses to RAM addresses.

The main issue is that the address bus on actual cartridges with a GSU chip is only 17 bits wide, and the mappings have to reflect that.

How I have implemented this in a related project (information partly based on higan):
```
/* Gamepak RAM (max. 128 kB):
   higan maps the gamepak RAM at:
       Bank 0x00-0x3f, Offset 6000-7fff
		 Bank 0x80-0xbf, Offset 6000-7fff
		 Bank 0x70-0x71, Offset 0000-ffff
		 Bank 0xf0-0xf1, Offset 0000-ffff
*/
assign is_ram = (!addr[22] & addr[15:13] == 3'b011) | (addr[22:17] == 6'b111000);

/* Gamepak RAM addresses map to physical RAM 2 as follows:
		Bank 0x00-0x3f: address 00aa bbbb 011c xxxx xxxx xxxx mapped to:
			b bbbc xxxx xxxx xxxx
		Bank 0x80-0xbf: address 10aa bbbb 011c xxxx xxxx xxxx mapped to:
			b bbbc xxxx xxxx xxxx
		Bank 0x70-0x71: address 0111 000a xxxx xxxx xxxx xxxx mapped to:
			a xxxx xxxx xxxx xxxx
		Bank 0xf0-0xf1: address 1111 000a xxxx xxxx xxxx xxxx mapped to:
			a xxxx xxxx xxxx xxxx
*/
assign ram_addr = !addr[22]
					? ({addr[19:16], addr[12:0]})
					: (addr[16:0]);
```

My notes differ from your implementation in two ways:
1. Using banks 0x70-0x71 and 0xf0-0xf1 instead of 0x70-0x7f and 0xf0-0xff (apparently the chip documentation and mappings higan uses agree on this point)
2. Addresses which have bits 16-19 containing something non-zero map to different physical RAM locations.

Both points can be explained by the address bus being 17 bits wide and using the banks to their fullest in expressing the entire address space of the (max. 128 kB) RAM.

Curiously, according to higan, the GSU-side mapping does repeat the mapping every two banks within 0x60-0x7f:0000-ffff.

These suggested changes change the SNES-side mapping to match my notes, which I believe are also in line with what higan does.